### PR TITLE
Fixed two examples and one VBO error

### DIFF
--- a/example-bodies/src/ofApp.cpp
+++ b/example-bodies/src/ofApp.cpp
@@ -121,9 +121,9 @@ void ofApp::draw()
 
 				// Spine.
 				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_PELVIS].position);
-				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_NAVAL].position);
+				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_NAVEL].position);
 
-				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_NAVAL].position);
+				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_NAVEL].position);
 				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_CHEST].position);
 
 				vertices[vdx++] = toGlm(skeleton.joints[K4ABT_JOINT_SPINE_CHEST].position);

--- a/example-pointcloud/src/ofApp.cpp
+++ b/example-pointcloud/src/ofApp.cpp
@@ -16,6 +16,10 @@ void ofApp::setup()
 	{
 		this->kinectDevice.startCameras();
 	}
+	glPointSize(2);
+	cam.rotateDeg(160, glm::vec3(0, 1, 0));
+	cam.rotateDeg(180, glm::vec3(0, 0, 1));
+
 }
 
 //--------------------------------------------------------------
@@ -34,7 +38,7 @@ void ofApp::update()
 void ofApp::draw()
 {
 	ofBackground(128);
-
+	ofEnableDepthTest();
 	if (this->kinectDevice.isStreaming())
 	{
 		this->cam.begin();
@@ -55,7 +59,7 @@ void ofApp::draw()
 		}
 		this->cam.end();
 	}
-
+	ofDisableDepthTest();
 	ofDrawBitmapString(ofToString(ofGetFrameRate(), 2) + " FPS", 10, 20);
 }
 

--- a/src/ofxAzureKinect/Device.cpp
+++ b/src/ofxAzureKinect/Device.cpp
@@ -376,7 +376,7 @@ namespace ofxAzureKinect
 		{
 			if (this->bUpdateColor)
 			{
-				this->updateWorldVbo(colorImg, this->colorToWorldImg);
+				this->updateWorldVbo(depthImg, this->colorToWorldImg);
 			}
 			else
 			{
@@ -427,7 +427,7 @@ namespace ofxAzureKinect
 
 	bool Device::setupColorToWorldTable()
 	{
-		if (this->setupImageToWorldTable(K4A_CALIBRATION_TYPE_COLOR, this->colorToWorldImg))
+		if (this->setupImageToWorldTable(K4A_CALIBRATION_TYPE_DEPTH, this->colorToWorldImg))
 		{
 			const int width = this->colorToWorldImg.get_width_pixels();
 			const int height = this->colorToWorldImg.get_height_pixels();
@@ -528,7 +528,7 @@ namespace ofxAzureKinect
 				if (frameData[idx] != 0 &&
 					tableData[idx].xy.x != 0 && tableData[idx].xy.y != 0)
 				{
-					float depthVal = static_cast<float>(frameData[idx]);
+					uint16_t depthVal = (frameData[idx]);
 					this->positionCache[numPoints] = glm::vec3(
 						tableData[idx].xy.x * depthVal,
 						tableData[idx].xy.y * depthVal,


### PR DESCRIPTION
Fixed a misspelling of"NAVEL" in the bodies example. Set a new camera starting orientation for PointCloud Example. Fixed issue in Device.cpp that broke VBOs with color.
The final change from float to uint_16 probably doesnt matter - it was part of my debugging.