### PR TITLE
use processing mode from body tracker settings

### DIFF
--- a/src/ofxAzureKinect/BodyTracker.cpp
+++ b/src/ofxAzureKinect/BodyTracker.cpp
@@ -31,7 +31,7 @@ namespace ofxAzureKinect
 
 		// Generate tracker config.
 		this->trackerConfig = K4ABT_TRACKER_CONFIG_DEFAULT;
-		this->trackerConfig.processing_mode = K4ABT_TRACKER_PROCESSING_MODE_GPU_CUDA;
+		this->trackerConfig.processing_mode = settings.processingMode;
 		this->trackerConfig.sensor_orientation = settings.sensorOrientation;
 		this->trackerConfig.gpu_device_id = settings.gpuDeviceID;
 


### PR DESCRIPTION
use the processing mode set in the "BodyTrackerSettings" object instead of always using "K4ABT_TRACKER_PROCESSING_MODE_GPU_CUDA"